### PR TITLE
docs: fix regression in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ As both addons mature, it is possible this functionality will merge into `ddev-d
     For DDEV v1.23.5 or above run
 
     ```shell
-    ddev add-on get tyler36/dbslow
+    ddev add-on get tyler36/ddev-dbslow
     ```
 
     For earlier versions of DDEV run
 
     ```shell
-    ddev get tyler36/dbslow
+    ddev get tyler36/ddev-dbslow
     ```
 
 2. Restart DDEV.


### PR DESCRIPTION
Seems like there was a regression in the installation instructions from #7

This PR corrects the plugin name.

Fixes #10